### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Dockerized 32-bit Firefox that works with Cisco WebEx, based on 32-bit Ubuntu (s
 
 ## Build
 
-	docker build -t ouyi/ubuntu32-firefox .
+	docker build -t ouyi/docker-ubuntu32-firefox .
 
 ## Run
 
 	xhost local:$(whoami)
-	docker run --rm -ti -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY ouyi/ubuntu32-firefox
+	docker run --rm -ti -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY ouyi/docker-ubuntu32-firefox
 
 ## Known issues
 


### PR DESCRIPTION
Hi!
I think there is should be docker-ubuntu32-firefox instead of ubuntu32-firefox.
